### PR TITLE
Minor optimizations

### DIFF
--- a/segment_anything/utils/transforms.py
+++ b/segment_anything/utils/transforms.py
@@ -29,20 +29,19 @@ class ResizeLongestSide:
         """
         target_size = self.get_preprocess_shape(image.shape[0], image.shape[1], self.target_length)
         return np.array(resize(to_pil_image(image), target_size))
-
+    
     def apply_coords(self, coords: np.ndarray, original_size: Tuple[int, ...]) -> np.ndarray:
         """
         Expects a numpy array of length 2 in the final dimension. Requires the
         original image size in (H, W) format.
         """
         old_h, old_w = original_size
-        new_h, new_w = self.get_preprocess_shape(
-            original_size[0], original_size[1], self.target_length
-        )
-        coords = deepcopy(coords).astype(float)
-        coords[..., 0] = coords[..., 0] * (new_w / old_w)
-        coords[..., 1] = coords[..., 1] * (new_h / old_h)
-        return coords
+        new_h, new_w = self.get_preprocess_shape(old_h, old_w, self.target_length)
+        new_coords = np.empty_like(coords)
+        new_coords[..., 0] = coords[..., 0] * (new_w / old_w)
+        new_coords[..., 1] = coords[..., 1] * (new_h / old_h)
+        return new_coords
+
 
     def apply_boxes(self, boxes: np.ndarray, original_size: Tuple[int, ...]) -> np.ndarray:
         """


### PR DESCRIPTION
Now avoids creating a deep copy of the coords array and instead creates a new array with the same shape and data type as coords using `np.empty_like`. Improves performance by reducing memory usage.