### PR TITLE
Bug fix, missing parameter to process() function

### DIFF
--- a/pre_grey_rgb2D.py
+++ b/pre_grey_rgb2D.py
@@ -187,7 +187,7 @@ else:
     # print the number of images found in the ground truth folder
     print("image number:", len(names))
     for gt_name in tqdm(names):
-        process(gt_name)
+        process(gt_name, None)
 
 # create a directory to save the npz files
 save_path = args.npz_path + "_" + args.model_type


### PR DESCRIPTION
I was reproducing the finetuning process for the 2D images, and came across this small bug when not using the CSV feature. Adding the `None` param let me run the preprocessing script again.