### PR TITLE
fix: replace undefined self.npy_files with correct path in assertion messages

### DIFF
--- a/comparisons/DeepLabV3+/train_deeplabv3_res50.py
+++ b/comparisons/DeepLabV3+/train_deeplabv3_res50.py
@@ -75,7 +75,7 @@ class NpyDataset(Dataset):
 
     def __getitem__(self, index):
         img_name = os.path.basename(self.gt_path_files[index])
-        assert img_name == os.path.basename(self.gt_path_files[index]), 'img gt name error' + self.gt_path_files[index] + self.npy_files[index]
+        assert img_name == os.path.basename(self.gt_path_files[index]), 'img gt name error: img=' + join(self.img_path, img_name) + ' gt=' + self.gt_path_files[index]
         img_3c = np.load(join(self.img_path, img_name), 'r', allow_pickle=True) # (H, W, 3)
         resize_img_cv2 = cv2.resize(
             img_3c,

--- a/extensions/point_prompt/train_point_prompt.py
+++ b/extensions/point_prompt/train_point_prompt.py
@@ -120,7 +120,7 @@ class NpyDataset(Dataset):
 
     def __getitem__(self, index):
         img_name = os.path.basename(self.gt_path_files[index])
-        assert img_name == os.path.basename(self.gt_path_files[index]), 'img gt name error' + self.gt_path_files[index] + self.npy_files[index]
+        assert img_name == os.path.basename(self.gt_path_files[index]), 'img gt name error: img=' + join(self.img_path, img_name) + ' gt=' + self.gt_path_files[index]
         img_1024 = np.load(join(self.img_path, img_name), 'r', allow_pickle=True) # (H, W, 3)
         # convert the shape to (3, H, W)
         img_1024 = np.transpose(img_1024, (2, 0, 1)) # (3, 256, 256)

--- a/extensions/text_prompt/train_text_prompt.py
+++ b/extensions/text_prompt/train_text_prompt.py
@@ -139,7 +139,7 @@ class NpyDataset(Dataset):
 
     def __getitem__(self, index):
         img_name = basename(self.gt_path_files[index])
-        assert img_name == basename(self.gt_path_files[index]), 'img gt name error' + self.gt_path_files[index] + self.npy_files[index]
+        assert img_name == basename(self.gt_path_files[index]), 'img gt name error: img=' + join(self.img_path, img_name) + ' gt=' + self.gt_path_files[index]
         img_1024 = np.load(join(self.img_path, img_name), 'r', allow_pickle=True) # (H, W, 3)
         # convert the shape to (3, H, W)
         img_1024 = np.transpose(img_1024, (2, 0, 1)) # (3, 256, 256)

--- a/train_multi_gpus.py
+++ b/train_multi_gpus.py
@@ -82,7 +82,7 @@ class NpyDataset(Dataset):
             self.gt_path_files[index], "r", allow_pickle=True
         )  # multiple labels [0, 1,4,5...], (256,256)
         assert img_name == os.path.basename(self.gt_path_files[index]), (
-            "img gt name error" + self.gt_path_files[index] + self.npy_files[index]
+            "img gt name error: img=" + join(self.img_path, img_name) + " gt=" + self.gt_path_files[index]
         )
         label_ids = np.unique(gt)[1:]
         gt2D = np.uint8(

--- a/train_one_gpu.py
+++ b/train_one_gpu.py
@@ -89,7 +89,7 @@ class NpyDataset(Dataset):
             self.gt_path_files[index], "r", allow_pickle=True
         )  # multiple labels [0, 1,4,5...], (256,256)
         assert img_name == os.path.basename(self.gt_path_files[index]), (
-            "img gt name error" + self.gt_path_files[index] + self.npy_files[index]
+            "img gt name error: img=" + join(self.img_path, img_name) + " gt=" + self.gt_path_files[index]
         )
         label_ids = np.unique(gt)[1:]
         gt2D = np.uint8(


### PR DESCRIPTION
## Summary

Fixes an `AttributeError` caused by referencing the undefined attribute `self.npy_files` in assertion error messages across all 5 `NpyDataset` classes in the codebase.

## Problem

All 5 training scripts (`train_one_gpu.py`, `train_multi_gpus.py`, `extensions/point_prompt/train_point_prompt.py`, `extensions/text_prompt/train_text_prompt.py`, `comparisons/DeepLabV3+/train_deeplabv3_res50.py`) contain an assertion in `NpyDataset.__getitem__()` that references `self.npy_files[index]` in its error message:

```python
assert img_name == os.path.basename(self.gt_path_files[index]), (
    'img gt name error' + self.gt_path_files[index] + self.npy_files[index]
)
```

However, the `NpyDataset` class never defines `self.npy_files` — only `self.gt_path_files`. This means:
- If the assertion ever triggers, it crashes with `AttributeError: 'NpyDataset' object has no attribute 'npy_files'` instead of showing the intended diagnostic error message
- The actual name mismatch is silently masked by the secondary exception

## Fix

Replace `self.npy_files[index]` with `join(self.img_path, img_name)` to show the full image path alongside the ground truth path, which is the intended diagnostic output:

```python
assert img_name == os.path.basename(self.gt_path_files[index]), (
    'img gt name error: img=' + join(self.img_path, img_name) + ' gt=' + self.gt_path_files[index]
)
```

## Verification

- ✅ All 5 modified files pass Python syntax check (`ast.parse`)
- ✅ Zero remaining references to `self.npy_files` in the entire codebase
- ✅ Error message now shows both the image path and ground truth path for debugging

## Files Changed

| File | Line | Change |
|------|------|--------|
| `train_one_gpu.py` | 92 | `self.npy_files[index]` → `join(self.img_path, img_name)` |
| `train_multi_gpus.py` | 85 | `self.npy_files[index]` → `join(self.img_path, img_name)` |
| `extensions/point_prompt/train_point_prompt.py` | 123 | `self.npy_files[index]` → `join(self.img_path, img_name)` |
| `extensions/text_prompt/train_text_prompt.py` | 142 | `self.npy_files[index]` → `join(self.img_path, img_name)` |
| `comparisons/DeepLabV3+/train_deeplabv3_res50.py` | 78 | `self.npy_files[index]` → `join(self.img_path, img_name)` |

Fixes #399

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-v2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
